### PR TITLE
move non-runtime dependencies to devDependencies section

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ clean:
 	rm -rf docs
 
 docs:
-	docco lib/*.js
+	node_modules/.bin/docco lib/*.js
 	#scp -rp docs/* root@yellow:/var/www/drupal/barricane-db/
 	#google-chrome http://www.barricane.com/barricane-db/
 

--- a/lib/levenshtein.js
+++ b/lib/levenshtein.js
@@ -140,7 +140,7 @@ Lev.prototype.actions = function() {
         deletes.push(action);
         i--;
       } else {
-        consolewarnlog("impossible condition");
+        console.warn("impossible condition");
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
   "engines": {
     "node": ">=0.2.6"
   },
-  "dependencies": {
-    "vows": "~0.6.4",
-    "docco": ">=0.3.0"
+  "devDependencies": {
+    "docco": ">=0.3.0",
+    "vows": "^0.8.1"
   }
 }


### PR DESCRIPTION
When you use `levenshtein-deltas` as a dependency, some packages which are only useful during package development (docs generator and test runner) are also installed. It can be optimised, by moving them into `devDependencies`.